### PR TITLE
Make decoding way easy to customize. Add more friendly API.

### DIFF
--- a/Sources/MoyaAPIClient/APIClient.swift
+++ b/Sources/MoyaAPIClient/APIClient.swift
@@ -2,9 +2,15 @@ import Foundation
 import Moya
 
 public protocol APIClient<Target> {
-    associatedtype Target: TargetType
+    associatedtype Target: APITarget
+
+    @available(swift, deprecated: 1.2.0, renamed: "send")
     func request<Response: Decodable>(with target: Target) async throws -> Response
+    @available(swift, deprecated: 1.2.0, renamed: "send")
     func request(with target: Target) async throws
+
+    func send<Response: Decodable>(with target: Target) async throws -> Response
+    func send(with target: Target) async throws
 }
 
 public enum APIClientError: Error {
@@ -12,13 +18,8 @@ public enum APIClientError: Error {
     case underlying(Error)
 }
 
-public struct APIClientImpl<Target: TargetType> {
+public struct APIClientImpl<Target: APITarget> {
     private var provider: MoyaProvider<Target>
-    private let jsonDecoder: JSONDecoder = {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return decoder
-    }()
 
     public init(provider: MoyaProvider<Target> = .init()) {
         self.provider = provider
@@ -35,7 +36,7 @@ public struct APIClientImpl<Target: TargetType> {
 
 extension APIClientImpl: APIClient {
 
-    public func request<Response>(with target: Target) async throws -> Response where Response : Decodable {
+    public func send<Response>(with target: Target) async throws -> Response where Response : Decodable {
         let response: Response = try await withCheckedThrowingContinuation { continuation in
             provider.request(target) { result in
                 switch result {
@@ -43,7 +44,7 @@ extension APIClientImpl: APIClient {
                     continuation.resume(throwing: APIClientError.underlying(error))
                 case .success(let response):
                     do {
-                        let codableResponse = try jsonDecoder.decode(Response.self, from: response.data)
+                        let codableResponse = try target.decoder.decode(Response.self, from: response.data)
                         continuation.resume(returning: codableResponse)
                     }
                     catch {
@@ -59,7 +60,7 @@ extension APIClientImpl: APIClient {
         return response
     }
 
-    public func request(with target: Target) async throws {
+    public func send(with target: Target) async throws {
         let _: Void = try await withCheckedThrowingContinuation({ continuation in
             provider.request(target) { result in
                 switch result {
@@ -72,4 +73,11 @@ extension APIClientImpl: APIClient {
         })
     }
 
+    public func request<Response>(with target: Target) async throws -> Response where Response : Decodable {
+        try await send(with: target)
+    }
+
+    public func request(with target: Target) async throws {
+        try await send(with: target)
+    }
 }

--- a/Sources/MoyaAPIClient/APIClientType.swift
+++ b/Sources/MoyaAPIClient/APIClientType.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Moya
 
-public protocol APIClient<Target> {
+protocol APIClientType<Target> {
     associatedtype Target: APITarget
 
     @available(swift, deprecated: 1.2.0, renamed: "send")
@@ -18,7 +18,7 @@ public enum APIClientError: Error {
     case underlying(Error)
 }
 
-public struct APIClientImpl<Target: APITarget> {
+public struct APIClient<Target: APITarget> {
     private var provider: MoyaProvider<Target>
 
     public init(provider: MoyaProvider<Target> = .init()) {
@@ -26,7 +26,7 @@ public struct APIClientImpl<Target: APITarget> {
     }
 
     public static func stub() -> Self {
-        APIClientImpl(
+        APIClient(
             provider: MoyaProvider<Target>(
                 stubClosure: MoyaProvider.immediatelyStub
             )
@@ -34,7 +34,7 @@ public struct APIClientImpl<Target: APITarget> {
     }
 }
 
-extension APIClientImpl: APIClient {
+extension APIClient: APIClientType {
 
     public func send<Response>(with target: Target) async throws -> Response where Response : Decodable {
         let response: Response = try await withCheckedThrowingContinuation { continuation in
@@ -73,10 +73,12 @@ extension APIClientImpl: APIClient {
         })
     }
 
+    @available(swift, deprecated: 1.2.0, renamed: "send")
     public func request<Response>(with target: Target) async throws -> Response where Response : Decodable {
         try await send(with: target)
     }
 
+    @available(swift, deprecated: 1.2.0, renamed: "send")
     public func request(with target: Target) async throws {
         try await send(with: target)
     }

--- a/Sources/MoyaAPIClient/APITarget.swift
+++ b/Sources/MoyaAPIClient/APITarget.swift
@@ -4,8 +4,8 @@ import Moya
 public protocol APITarget: TargetType {
     var decoder: JSONDecoder { get }
 
-    func send<Response: Decodable>(client: (any APIClient<Self>)?) async throws -> Response
-    func send(client: (any APIClient<Self>)?) async throws
+    func send<Response: Decodable>(client: (APIClient<Self>)?) async throws -> Response
+    func send(client: (APIClient<Self>)?) async throws
 }
 
 public extension APITarget {
@@ -17,18 +17,20 @@ public extension APITarget {
 }
 
 public extension APITarget {
-    func send<Response: Decodable>(client: (any APIClient<Self>)? = nil) async throws -> Response {
+    func send<Response: Decodable>(client: (APIClient<Self>)? = nil) async throws -> Response {
         if let client {
             return try await client.send(with: self)
         } else {
-            return try await APIClientImpl<Self>().send(with: self)
+            return try await APIClient<Self>().send(with: self)
         }
     }
-    func send(client: (any APIClient<Self>)? = nil) async throws {
+    func send(client: (APIClient<Self>)? = nil) async throws {
         if let client {
             try await client.send(with: self)
         } else {
-            try await APIClientImpl<Self>().send(with: self)
+            try await APIClient<Self>().send(with: self)
         }
     }
+
+
 }

--- a/Sources/MoyaAPIClient/APITarget.swift
+++ b/Sources/MoyaAPIClient/APITarget.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Moya
+
+public protocol APITarget: TargetType {
+    var decoder: JSONDecoder { get }
+
+    func send<Response: Decodable>(client: (any APIClient<Self>)?) async throws -> Response
+    func send(client: (any APIClient<Self>)?) async throws
+}
+
+public extension APITarget {
+    var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+}
+
+public extension APITarget {
+    func send<Response: Decodable>(client: (any APIClient<Self>)? = nil) async throws -> Response {
+        if let client {
+            return try await client.send(with: self)
+        } else {
+            return try await APIClientImpl<Self>().send(with: self)
+        }
+    }
+    func send(client: (any APIClient<Self>)? = nil) async throws {
+        if let client {
+            try await client.send(with: self)
+        } else {
+            try await APIClientImpl<Self>().send(with: self)
+        }
+    }
+}

--- a/Tests/MoyaAPIClientTests/APIClientTests.swift
+++ b/Tests/MoyaAPIClientTests/APIClientTests.swift
@@ -3,7 +3,7 @@ import Moya
 @testable import MoyaAPIClient
 
 final class APIClientTests: XCTestCase {
-    enum SimpleRequest: TargetType {
+    enum SimpleRequest: APITarget {
         case index
         case failableIndex
 
@@ -52,7 +52,7 @@ final class APIClientTests: XCTestCase {
     func test() async throws {
         let client = APIClientImpl<SimpleRequest>.stub()
         let expectedResponse = SimpleResponse(message: "This is stub message.")
-        let response: SimpleResponse = try await client.request(with: .index)
+        let response: SimpleResponse = try await client.send(with: .index)
         XCTAssertEqual(response, expectedResponse)
     }
 
@@ -60,7 +60,7 @@ final class APIClientTests: XCTestCase {
         let client = APIClientImpl<SimpleRequest>.stub()
         let expectedCodingKeyForError = SimpleResponse.CodingKeys.message
         do {
-            let _: SimpleResponse = try await client.request(with: .failableIndex)
+            let _: SimpleResponse = try await client.send(with: .failableIndex)
         } catch APIClientError.faildToDecodeCodable(let error) {
             if case let DecodingError.keyNotFound(codingKeys, _) = error {
                 guard let codingKeys = codingKeys as? SimpleResponse.CodingKeys else {

--- a/Tests/MoyaAPIClientTests/APIClientTests.swift
+++ b/Tests/MoyaAPIClientTests/APIClientTests.swift
@@ -50,14 +50,14 @@ final class APIClientTests: XCTestCase {
     }
 
     func test() async throws {
-        let client = APIClientImpl<SimpleRequest>.stub()
+        let client = APIClient<SimpleRequest>.stub()
         let expectedResponse = SimpleResponse(message: "This is stub message.")
         let response: SimpleResponse = try await client.send(with: .index)
         XCTAssertEqual(response, expectedResponse)
     }
 
     func test_decodingError() async throws {
-        let client = APIClientImpl<SimpleRequest>.stub()
+        let client = APIClient<SimpleRequest>.stub()
         let expectedCodingKeyForError = SimpleResponse.CodingKeys.message
         do {
             let _: SimpleResponse = try await client.send(with: .failableIndex)
@@ -72,5 +72,12 @@ final class APIClientTests: XCTestCase {
             }
         }
         XCTFail()
+    }
+
+    func test_target_oriented_api() async throws {
+        let expectedResponse = SimpleResponse(message: "This is stub message.")
+        let request = SimpleRequest.index
+        let response: SimpleResponse = try await request.send(client: .stub())
+        XCTAssertEqual(response, expectedResponse)
     }
 }


### PR DESCRIPTION
- No more need to prepare `APIClientImpl` when calling APIRequest.
- Decoding strategy is fully delegated to each `APITarget`.
- Rename `APIClient.request` to `APIClient.send`.
- Hide interface of `APIClient`.